### PR TITLE
Fix arctan input handling and improve logic clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project demonstrates an application example using RAH (Real-time Applicatio
 
 The CORDIC-based implementation allows users to compute the following functions efficiently on FPGA:
 
-1. **Trigonometric Functions**: Computes sin, cos, arcsin, and arccos.
+1. **Trigonometric Functions**: Computes sin, cos, arcsin, arccos, and arctan.
 2. **Hyperbolic Functions**: Computes sinh, cosh, and tanh.
 3. **Logarithmic and Exponential**: Computes ln and exp.
 4. **Square Root**: Computes sqrt.
@@ -37,8 +37,6 @@ RAH is a protocol developed by Vicharak to facilitate efficient data transfer be
    - The RAH Services encapsulate this data and send it back to the CPU.
    - The CPU decodes the frame and extracts the computed results.
 
-This structured communication ensures an efficient and organized transfer of data between the CPU and FPGA, making real-time computations feasible.
-
 ## FPGA User Guide
 
 ### Input Frame Format
@@ -52,6 +50,14 @@ The FPGA receives input frames via the RAH communication interface. The input fr
 
   ![image](images/Input_data_frame_structure.svg)
 
+#### Special Case: Arctan Function
+For the **arctan** function, **two input frames** are required, as it involves two input values instead of one.
+The RAH protocol ensures that these frames are sent sequentially and processed accordingly by the FPGA.
+
+#### Example
+```sh
+Input packet: 00 08 00 01 00 00 00 08 00 00 00 00
+```
 - **Mode Selection**:
   - **Mode 1**: Computes Sin and Cos
   - **Mode 2**: Computes Hyperbolic Sine (sinh) and Hyperbolic Cosine (cosh)
@@ -60,8 +66,7 @@ The FPGA receives input frames via the RAH communication interface. The input fr
   - **Mode 5**: Computes Exponential (exp)
   - **Mode 6**: Computes Natural Logarithm (ln)
   - **Mode 7**: Computes Square Root (sqrt)
-
-Using the RAH communication terminal, users can send up to 3KB of data at once to the FPGA, allowing for batch processing of multiple computations.
+  - **Mode 8**: Computes Arctan
 
 ### Output Frame Format
 As per the design, the output frame received on the terminal (through RAH communication) follows this format:
@@ -84,4 +89,3 @@ As per the design, the output frame received on the terminal (through RAH commun
 
 ## Conclusion
 This project showcases an efficient implementation of the CORDIC algorithm on FPGA using Verilog, integrated with RAH for seamless communication between the CPU and FPGA. The design supports a range of mathematical functions, making it a versatile solution for hardware-accelerated computing applications.
-

--- a/rah.peri.xml
+++ b/rah.peri.xml
@@ -21,7 +21,7 @@
         </efxpt:ctrl_info>
     </efxpt:device_info>
     <efxpt:gpio_info device_def="T120F324">
-        <efxpt:gpio name="clk" gpio_def="GPIOR_186" mode="input" bus_name="" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
+        <efxpt:gpio name="clk" gpio_def="GPIOR_166" mode="input" bus_name="" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="clk" name_ddio_lo="" conn_type="pll_clkin" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
         </efxpt:gpio>
         <efxpt:gpio name="mipi_refclk" gpio_def="GPIOR_169" mode="input" bus_name="" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
@@ -30,7 +30,7 @@
         <efxpt:gpio name="mipi_rx_refclk" gpio_def="GPIOR_188" mode="input" bus_name="" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="mipi_rx_refclk" name_ddio_lo="" conn_type="pll_clkin" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
         </efxpt:gpio>
-        <efxpt:gpio name="mipi_tx_refclk" gpio_def="GPIOL_15" mode="input" bus_name="" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
+        <efxpt:gpio name="mipi_tx_refclk" gpio_def="GPIOR_167" mode="input" bus_name="" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="mipi_tx_refclk" name_ddio_lo="" conn_type="pll_clkin" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
         </efxpt:gpio>
         <efxpt:gpio name="uart_rx_pin" gpio_def="GPIOT_RXN24" mode="input" bus_name="" is_lvds_gpio="true" io_standard="3.3 V LVTTL / LVCMOS">
@@ -47,14 +47,14 @@
             <efxpt:output_clock name="mipi_rx_cal_clk" number="1" out_divider="5" adv_out_phase_shift="0"/>
             <efxpt:adv_prop ref_clock_mode="external" ref_clock1_name="" ext_ref_clock_id="2" clksel_name="" feedback_clock_name="" feedback_mode="internal"/>
         </efxpt:pll>
-        <efxpt:pll name="pll_inst2" pll_def="PLL_BL0" ref_clock_name="" ref_clock_freq="30.0000" multiplier="86" pre_divider="3" post_divider="8" reset_name="" locked_name="" is_ipfrz="false" is_bypass_lock="true">
-            <efxpt:output_clock name="tx_pixel_clk" number="0" out_divider="2" adv_out_phase_shift="0"/>
-            <efxpt:output_clock name="tx_vga_clk" number="2" out_divider="1" adv_out_phase_shift="0"/>
-            <efxpt:output_clock name="cordic_clk" number="1" out_divider="256" adv_out_phase_shift="0"/>
+        <efxpt:pll name="pll_inst4" pll_def="PLL_TR1" ref_clock_name="" ref_clock_freq="20.0000" multiplier="54" pre_divider="1" post_divider="2" reset_name="" locked_name="" is_ipfrz="false" is_bypass_lock="true">
+            <efxpt:output_clock name="tx_pixel_clk" number="0" out_divider="10" adv_out_phase_shift="0"/>
+            <efxpt:output_clock name="tx_vga_clk" number="1" out_divider="5" adv_out_phase_shift="0"/>
             <efxpt:adv_prop ref_clock_mode="external" ref_clock1_name="" ext_ref_clock_id="2" clksel_name="" feedback_clock_name="" feedback_mode="internal"/>
         </efxpt:pll>
-        <efxpt:pll name="pll_inst3" pll_def="PLL_BR0" ref_clock_name="" ref_clock_freq="50.0000" multiplier="32" pre_divider="1" post_divider="8" reset_name="" locked_name="" is_ipfrz="false" is_bypass_lock="true">
-            <efxpt:output_clock name="tx_esc_clk" number="0" out_divider="10" adv_out_phase_shift="0"/>
+        <efxpt:pll name="pll_inst4_" pll_def="PLL_TR0" ref_clock_name="" ref_clock_freq="74.2500" multiplier="72" pre_divider="5" post_divider="2" reset_name="" locked_name="" is_ipfrz="false" is_bypass_lock="true">
+            <efxpt:output_clock name="tx_esc_clk" number="0" out_divider="5" adv_out_phase_shift="0"/>
+            <efxpt:output_clock name="cordic_clk" number="1" out_divider="28" adv_out_phase_shift="0"/>
             <efxpt:adv_prop ref_clock_mode="external" ref_clock1_name="" ext_ref_clock_id="2" clksel_name="" feedback_clock_name="" feedback_mode="internal"/>
         </efxpt:pll>
     </efxpt:pll_info>

--- a/rah.xml
+++ b/rah.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<efx:project name="rah" description="" last_change="1742020995" sw_version="2023.2.307" last_run_state="pass" last_run_flow="bitstream" config_result_in_sync="true" design_ood="sync" place_ood="sync" route_ood="sync" xmlns:efx="http://www.efinixinc.com/enf_proj" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.efinixinc.com/enf_proj enf_proj.xsd">
+<efx:project name="rah" description="" last_change="1742808916" sw_version="2023.2.307" last_run_state="pass" last_run_flow="bitstream" config_result_in_sync="true" design_ood="sync" place_ood="sync" route_ood="sync" xmlns:efx="http://www.efinixinc.com/enf_proj" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.efinixinc.com/enf_proj enf_proj.xsd">
     <efx:device_info>
         <efx:family name="Trion"/>
         <efx:device name="T120F324"/>


### PR DESCRIPTION
Added description of arctan requiring 2 inputs in the README. Modified cordic_mode_controller:
- In WR_IDLE, i_data2 is no longer reset prematurely because arctan requires 2 input frames from RAH.
- Changed count from 1-bit to 2-bit to improve conditional logic clarity.