### PR TITLE
fix(cordic): Corrected control flow logic for mode 3

### DIFF
--- a/cordic.peri.xml
+++ b/cordic.peri.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<efxpt:design_db name="cordic" device_def="T120F324" location="/home/dev/Vicharak/cordic" version="2023.2.307" db_version="20232999" last_change_date="Thu Apr 17 11:00:02 2025" xmlns:efxpt="http://www.efinixinc.com/peri_design_db" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.efinixinc.com/peri_design_db peri_design_db.xsd ">
+<efxpt:design_db name="cordic" device_def="T120F324" version="2024.2.294" db_version="20242999" last_change_date="Tue Apr 22 11:14:22 2025" xmlns:efxpt="http://www.efinixinc.com/peri_design_db" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.efinixinc.com/peri_design_db peri_design_db.xsd ">
     <efxpt:device_info>
         <efxpt:iobank_info>
             <efxpt:iobank name="1A" iostd="3.3 V LVTTL / LVCMOS"/>
@@ -51,9 +51,9 @@
             <efxpt:output_clock name="tx_pixel_clk" number="0" out_divider="10" adv_out_phase_shift="0"/>
             <efxpt:adv_prop ref_clock_mode="external" ref_clock1_name="" ext_ref_clock_id="2" clksel_name="" feedback_clock_name="" feedback_mode="internal"/>
         </efxpt:pll>
-        <efxpt:pll name="pll_inst4_" pll_def="PLL_TR0" ref_clock_name="" ref_clock_freq="74.2500" multiplier="121" pre_divider="6" post_divider="2" reset_name="" locked_name="" is_ipfrz="false" is_bypass_lock="true">
-            <efxpt:output_clock name="tx_esc_clk" number="0" out_divider="7" adv_out_phase_shift="0"/>
-            <efxpt:output_clock name="cordic_clk" number="1" out_divider="50" adv_out_phase_shift="0"/>
+        <efxpt:pll name="pll_inst4_" pll_def="PLL_TR0" ref_clock_name="" ref_clock_freq="74.2500" multiplier="121" pre_divider="7" post_divider="2" reset_name="" locked_name="" is_ipfrz="false" is_bypass_lock="true">
+            <efxpt:output_clock name="tx_esc_clk" number="0" out_divider="6" adv_out_phase_shift="0"/>
+            <efxpt:output_clock name="cordic_clk" number="1" out_divider="32" adv_out_phase_shift="0"/>
             <efxpt:adv_prop ref_clock_mode="external" ref_clock1_name="" ext_ref_clock_id="2" clksel_name="" feedback_clock_name="" feedback_mode="internal"/>
         </efxpt:pll>
     </efxpt:pll_info>

--- a/rtl/constraints.sdc
+++ b/rtl/constraints.sdc
@@ -2,6 +2,6 @@ create_clock -period 18.5185 tx_pixel_clk
 create_clock -period 9.2593 tx_esc_clk
 create_clock -period 9.2593 mipi_rx_cal_clk
 create_clock -period 18.5185 rx_pixel_clk
-create_clock -period 66.7833 cordic_clk
+create_clock -period 49.865 cordic_clk
 
 set_clock_groups -exclusive -group {tx_pixel_clk} -group {rx_pixel_clk mipi_rx_cal_clk} -group {tx_esc_clk cordic_clk}

--- a/rtl/cordic_mode_controller.v
+++ b/rtl/cordic_mode_controller.v
@@ -84,8 +84,8 @@ always @(posedge clk) begin
             if (rdata[39:32] == 8) begin
                 if (!count) begin
                     i_data <= rdata[31:0];
-                    count <= 1;
                     rd_state <= RD_IDLE;
+                    count <= 1;
                 end else if (count == 1) begin
                     i_data2 <= rdata[31:0];
                     i_call <= 1;
@@ -178,6 +178,7 @@ always @(posedge clk) begin
             W_SEND: begin
                 wr_data <= {16'h000b,out_data_tan}; //tanh
                 wr_state <= W_IDLE;
+                wr_en <= 1;
            end
         endcase
     end 


### PR DESCRIPTION
- In mode 3 (tanh), 'wr_en' signal was not asserted during the 'W_SEND' state, causing output not to latch — now fixed.
- changed cordic_clk from 15Mhz to 20Mhz